### PR TITLE
BAU - Update module with fork to 0.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.99.5
+    hooks:
+      - id: terraform_fmt

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,12 @@ variable "workspace_tags" {
   default     = []
 }
 
+variable "workspace_map_tags" {
+  type        = map(string)
+  description = "Map of key value tags to apply to Workspace."
+  default     = {}
+}
+
 variable "terraform_version" {
   type        = string
   description = "Version of Terraform to use for this Workspace."

--- a/workspace.tf
+++ b/workspace.tf
@@ -11,6 +11,7 @@ resource "tfe_workspace" "ws" {
   structured_run_output_enabled = var.structured_run_output_enabled
   ssh_key_id                    = var.ssh_key_id
   tag_names                     = var.workspace_tags
+  tag                           = var.workspace_map_tags
   terraform_version             = var.terraform_version
   trigger_prefixes              = var.trigger_prefixes
   trigger_patterns              = var.trigger_patterns


### PR DESCRIPTION
Description:
- Fork is now on [0.13](https://github.com/alexbasista/terraform-tfe-workspacer/releases/tag/v0.13.0)
- [0.13](https://github.com/alexbasista/terraform-tfe-workspacer/pull/30) included `workspace_map_tags`
- Add a pre-commit hook that formats Terraform