### PR TITLE
Add variable for specifying a list of tfvars files

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,19 @@ variable "envvars_ignore_changes" {
   default     = {}
 }
 
+variable "tfvars_files_prefix" {
+  type        = string
+  description = "Prefix for Terraform variable file paths added to Workspace."
+  # This has to be workspace-relative, so set a default that works with the expected directory structure of govuk-infrastructure, but can be overridden if needed.
+  default     = "../../variables/"
+}
+
+variable "tfvars_files" {
+  type        = list(string)
+  description = "List of file paths relative to /terraform/variables to load Terraform variables from."
+  default     = []
+}
+
 #------------------------------------------------------------------------------
 # Team Access
 #------------------------------------------------------------------------------

--- a/workspace_variables.tf
+++ b/workspace_variables.tf
@@ -1,3 +1,19 @@
+locals {
+  tfvars_files_args = [
+    for file in var.tfvars_files : "-var-file=\"${var.tfvars_files_prefix}${file}\""
+  ]
+  # Add -var-file arguments to envvars, ensuring that any existing TF_CLI_ARGS_plan or TF_CLI_ARGS_apply are preserved
+  envvars = merge(
+    var.envvars,
+    {
+      TF_CLI_ARGS_plan  = trimspace(join(" ", concat([lookup(var.envvars, "TF_CLI_ARGS_plan", "")], local.tfvars_files_args)))
+      TF_CLI_ARGS_apply = trimspace(join(" ", concat([lookup(var.envvars, "TF_CLI_ARGS_apply", "")], local.tfvars_files_args)))
+    }
+  )
+  # Filter out any envvars with empty values to avoid setting them in the workspace
+  envvars_filtered = { for k, v in local.envvars : k => v if v != "" }
+}
+
 resource "tfe_variable" "tfvars" {
   for_each = var.tfvars
 
@@ -23,7 +39,7 @@ resource "tfe_variable" "tfvars_sensitive" {
 }
 
 resource "tfe_variable" "envvars" {
-  for_each = var.envvars
+  for_each = local.envvars_filtered
 
   workspace_id = tfe_workspace.ws.id
   key          = each.key


### PR DESCRIPTION
This allows us to use tfvars files for TFC workspaces instead of TFC var sets. This is desirable because it allows for actual TF plans in PRs.

https://github.com/alphagov/govuk-infrastructure/issues/3820